### PR TITLE
Make the description match the style of the mania and catch mirror mod

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModMirror.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModMirror.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override string Name => "Mirror";
         public override string Acronym => "MR";
-        public override LocalisableString Description => "Notes come from the left instead of the right.";
+        public override LocalisableString Description => "Notes are flipped horizontally.";
         public override double ScoreMultiplier => 1;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)


### PR DESCRIPTION
This PR simplifies the description of the mirror mod for Taiko to match the style of the of the mania and catch mirror mod description.

See
https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs#L16
https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Catch/Mods/CatchModMirror.cs#L18