### PR TITLE
Move the mirror mod from the fun to conversion section

### DIFF
--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -152,6 +152,7 @@ namespace osu.Game.Rulesets.Taiko
                         new TaikoModSwap(),
                         new TaikoModSingleTap(),
                         new TaikoModConstantSpeed(),
+                        new TaikoModMirror()
                     };
 
                 case ModType.Automation:
@@ -166,8 +167,7 @@ namespace osu.Game.Rulesets.Taiko
                     {
                         new MultiMod(new ModWindUp(), new ModWindDown()),
                         new TaikoModMuted(),
-                        new ModAdaptiveSpeed(),
-                        new TaikoModMirror()
+                        new ModAdaptiveSpeed()
                     };
 
                 case ModType.System:


### PR DESCRIPTION
This imo makes more sense since the rest of the mirror mods are already in the conversion section anyways.

https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/ManiaRuleset.cs#L262
https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/ManiaRuleset.cs#L262
